### PR TITLE
Corrected issues with multiobjective selection

### DIFF
--- a/AgentSimulator/Engine/Experiments/MultiAgentExperiment.cs
+++ b/AgentSimulator/Engine/Experiments/MultiAgentExperiment.cs
@@ -550,7 +550,6 @@ namespace Engine
                 }
             }
 
-            behavior.multiobjective = multiobjective;
             // Punish CPPN modules: Must use with multiobjective option
             if(cppnModuleCost)
             {

--- a/AgentSimulator/Engine/Experiments/MultiAgentExperiment.cs
+++ b/AgentSimulator/Engine/Experiments/MultiAgentExperiment.cs
@@ -466,7 +466,7 @@ namespace Engine
 
                     inst.agentBrain = new AgentBrain(homogeneousTeam, inst.num_rbts, substrateDescription, network, normalizeWeights, adaptableANN, modulatoryANN, multibrain, numBrains, evolveSubstrate, preferenceNeurons, forcedSituationalPolicyGeometry);
                     // Add up the links in each substrate brain
-                    // Recalculates each evaluation (wasteful), but resets to 0 each time (correct).
+                    // Recalculates each evaluation, but resets to 0 each time.
                     linksInSubstrate = 0;
                     foreach (INetwork b in inst.agentBrain.multiBrains)
                     {

--- a/AgentSimulator/Engine/HyperNEATEvolver.cs
+++ b/AgentSimulator/Engine/HyperNEATEvolver.cs
@@ -95,7 +95,7 @@ namespace Engine
             }
             //Console.WriteLine(ea.Generation.ToString() + " " + ea.BestGenome.RealFitness + " "  + ea.Population.GenomeList.Count + " " + (DateTime.Now.Subtract(dt)));
             // Schrum: Changed this to include fitness values from each environment: Mainly for FourTasks
-            Console.WriteLine(ea.Generation.ToString() + " " + ea.BestGenome.RealFitness + " " + ea.Population.GenomeList.Count + " (" + string.Join(",", ea.BestGenome.Behavior.objectives) + ") " + (DateTime.Now.Subtract(dt)) + " ID:" + ea.BestGenome.GenomeId + " " + ea.BestGenome.Behavior.modules + " " + ea.BestGenome.Behavior.cppnLinks + " " + ea.BestGenome.Behavior.substrateLinks);
+            Console.WriteLine(ea.Generation.ToString() + " " + ea.BestGenome.RealFitness + " " + ea.Population.GenomeList.Count + " (" + string.Join(",", ea.BestGenome.Behavior.objectives) + ") " + (DateTime.Now.Subtract(dt)) + " " + ea.BestGenome.Behavior.modules + " " + ea.BestGenome.Behavior.cppnLinks + " " + ea.BestGenome.Behavior.substrateLinks);
             int gen_mult = 200;
             if (logging)
             {

--- a/AgentSimulator/SharpNeatLib/Evolution/BehaviorType.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/BehaviorType.cs
@@ -13,12 +13,11 @@ namespace SharpNeatLib
         public List<double> behaviorList;
 		public double[] objectives;
 
-        // Schrum: These four fields are not related to "behavior" but
+        // Schrum: These three fields are not related to "behavior" but
         // this class is the most convenient place to store this information
         public int modules;
         public int cppnLinks;
         public int substrateLinks;
-        public bool multiobjective;
         
         public BehaviorType()
         {

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -1040,21 +1040,15 @@ namespace SharpNeatLib.Evolution
 
 				// Keep track of the population's best genome and max fitness.
 				NeatGenome.NeatGenome fittestgenome = (NeatGenome.NeatGenome)(species.Members[0]);
-
-                //SCHRUM: TODO: Still a problem here
-
-                if ((fittestgenome.RealFitness > bestFitness &&
-                    (bestGenome == null || // unless no best genome exists yet
-                     bestGenome.Behavior == null || bestGenome.Behavior.objectives == null || // unless other objectives are absent
-                     !fittestgenome.Behavior.multiobjective)) || // better fitness is not enough with multiobjective 
+				if(fittestgenome.RealFitness > bestFitness ||
                     // Fitness is the same, but multiple (really just 2) objectives
                     // are being used, and this new genome performs better in that second objective.
-                   (fittestgenome.RealFitness >= bestFitness &&
+                   (fittestgenome.RealFitness == bestFitness &&
                     fittestgenome.Behavior.multiobjective &&
                     fittestgenome.Behavior.objectives != null &&
                     bestGenome.Behavior != null &&
                     bestGenome.Behavior.objectives != null &&
-                    fittestgenome.Behavior.objectives[1] > bestGenome.Behavior.objectives[1]) )
+                    fittestgenome.Behavior.objectives[1] > bestGenome.Behavior.objectives[1]))
 				{
                     /**
                     Console.WriteLine(fittestgenome);

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -402,12 +402,31 @@ namespace SharpNeatLib.Evolution
                     k++;
                 }
                 **/
+
+
+
+
+
+
+
+
+
+
+                // Schrum: A command after this point, either truncate or reset pop, is eliminating the most fit individual from the population.
+
+
+
+
+
+
+
+
+
                 // This is the command that removes excess members of the population, like in NSGA-II
                 pop.ResetPopulation(multiobjective.truncatePopulation(pop.GenomeList.Count), this);
                 // Schrum: Change Fitness back to actual Fitness (rather than rank) before updating stats
                 for (int i = 0; i < pop.GenomeList.Count; i++)
                 {
-                    //Console.WriteLine(i + ": " + pop.GenomeList[i].RealFitness + "," + (pop.GenomeList[i].Behavior == null || pop.GenomeList[i].Behavior.objectives == null ? "null" : "" + pop.GenomeList[i].Behavior.objectives[1]));
                     // Not allowed to set Fitness to 0, so set it to MinValue if RealFitness is 0 (only true if agent is unevaluated so far)
                     double realFitness = pop.GenomeList[i].RealFitness == 0.0 ? EvolutionAlgorithm.MIN_GENOME_FITNESS : pop.GenomeList[i].RealFitness;
                     pop.GenomeList[i].Fitness = realFitness;

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -1089,14 +1089,15 @@ namespace SharpNeatLib.Evolution
                 // to find the best agent.
                 if (neatParameters.multiobjective)
                 {
-                    //Console.WriteLine("MULTIOBJECTIVE!");
                     foreach (NeatGenome.NeatGenome g in species.Members)
                     {
-                        if (fittestgenome.RealFitness > bestFitness 
+                        if ((fittestgenome.RealFitness > bestFitness &&
+                             (bestGenome == null || // unless no best genome exists yet 
+                              bestGenome.Behavior == null || bestGenome.Behavior.objectives == null)) // Or not evaluated 
                              || // better fitness is not enough with multiobjective 
                                 // Fitness is the same, but multiple (really just 2) objectives
                                 // are being used, and this new genome performs better in that second objective.
-                            (fittestgenome.RealFitness == bestFitness &&
+                            (fittestgenome.RealFitness >= bestFitness &&
                              fittestgenome.Behavior.objectives != null &&
                              bestGenome.Behavior != null &&
                              bestGenome.Behavior.objectives != null &&

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -391,39 +391,8 @@ namespace SharpNeatLib.Evolution
             if (neatParameters.multiobjective) {
 				multiobjective.addPopulation(pop);
 				multiobjective.rankGenomes();
-
-                // Schrum: for degugging
-                /**
-                Console.WriteLine("Population contents at generation " + generation);
-                int k = 0;
-                foreach (NeatGenome.NeatGenome g in pop.GenomeList)
-                {
-                    Console.WriteLine(k + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
-                    k++;
-                }
-                **/
-
-
-
-
-
-
-
-
-
-
-                // Schrum: A command after this point, either truncate or reset pop, is eliminating the most fit individual from the population.
-
-
-
-
-
-
-
-
-
                 // This is the command that removes excess members of the population, like in NSGA-II
-                pop.ResetPopulation(multiobjective.truncatePopulation(pop.GenomeList.Count), this);
+                pop.ResetPopulation(multiobjective.truncatePopulation(pop.GenomeList.Count),this);
                 // Schrum: Change Fitness back to actual Fitness (rather than rank) before updating stats
                 for (int i = 0; i < pop.GenomeList.Count; i++)
                 {
@@ -438,16 +407,30 @@ namespace SharpNeatLib.Evolution
 
             if (!regenerate)
             {
-                CreateOffSpring();
-                pop.TrimAllSpeciesBackToElite();
+			CreateOffSpring();
+			pop.TrimAllSpeciesBackToElite();
+            // Schrum: for degugging
+                /**
+                if (generation >= 9)
+                {
+                    Console.WriteLine("Population contents at generation " + generation);
+                    int i = 0;
+                    foreach (NeatGenome.NeatGenome g in pop.GenomeList)
+                    {
+                        if (g.Behavior != null && g.Behavior.objectives != null && g.Behavior.objectives[1] == -15) Console.Write("** ");
+                        Console.WriteLine(i + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
+                        i++;
+                    }
+                }
+                **/
                 // Add offspring to the population.
                 int genomeBound = offspringList.Count;
-                for (int genomeIdx = 0; genomeIdx < genomeBound; genomeIdx++)
-                    pop.AddGenomeToPopulation(this, offspringList[genomeIdx]);
+			for(int genomeIdx=0; genomeIdx<genomeBound; genomeIdx++)
+				pop.AddGenomeToPopulation(this, offspringList[genomeIdx]);
 
             }
-
-            // Adjust the speciation threshold to try and keep the number of species within defined limits.
+            
+			// Adjust the speciation threshold to try and keep the number of species within defined limits.
 			if(!neatParameters.multiobjective)
 			AdjustSpeciationThreshold();
 

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -1040,25 +1040,9 @@ namespace SharpNeatLib.Evolution
 
 				// Keep track of the population's best genome and max fitness.
 				NeatGenome.NeatGenome fittestgenome = (NeatGenome.NeatGenome)(species.Members[0]);
-				if(fittestgenome.RealFitness > bestFitness)
+				if(fittestgenome.Fitness > bestFitness)
 				{
-                    /**
-                    Console.WriteLine(fittestgenome);
-                    Console.WriteLine(fittestgenome.Behavior);
-                    Console.WriteLine(fittestgenome.Behavior.objectives);
-                    Console.WriteLine(fittestgenome.Behavior.objectives[0]);
-                    Console.WriteLine(fittestgenome.Behavior.objectives[1]);
-                    Console.WriteLine(bestGenome);
-                    Console.WriteLine(bestGenome.Behavior);
-                    Console.WriteLine(bestGenome.Behavior.objectives);
-                    Console.WriteLine(bestGenome.Behavior.objectives[0]);
-                    Console.WriteLine(bestGenome.Behavior.objectives[1]);
-                    **/
-                    //Console.WriteLine(fittestgenome.RealFitness + " > " + bestFitness);
-                    //Console.WriteLine("REPLACE BEST: " + (fittestgenome.Behavior == null || fittestgenome.Behavior.objectives == null ? fittestgenome.RealFitness + ",null " : fittestgenome.Behavior.objectives[0] + "," + fittestgenome.Behavior.objectives[1])
-                    //    + " is better than " + (bestGenome == null || bestGenome.Behavior == null || bestGenome.Behavior.objectives == null ? bestFitness + ",null " : bestGenome.Behavior.objectives[0] + "," + bestGenome.Behavior.objectives[1]));
-
-                    bestFitness = fittestgenome.RealFitness;
+				    bestFitness = fittestgenome.Fitness;
 				    bestGenome = fittestgenome;
 				}
 				

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -1040,7 +1040,9 @@ namespace SharpNeatLib.Evolution
 
 				// Keep track of the population's best genome and max fitness.
 				NeatGenome.NeatGenome fittestgenome = (NeatGenome.NeatGenome)(species.Members[0]);
-				if(fittestgenome.Fitness > bestFitness)
+				if(fittestgenome.RealFitness > bestFitness ||
+                    (fittestgenome.RealFitness == bestFitness && // At least as good in first
+                     fittestgenome.objectives[1] > bestGenome.objectives[1])) // better in second (assumes only two objectives: one real, and other secondary)
 				{
 				    bestFitness = fittestgenome.Fitness;
 				    bestGenome = fittestgenome;

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -393,6 +393,11 @@ namespace SharpNeatLib.Evolution
 				multiobjective.rankGenomes();
                 // This is the command that removes excess members of the population, like in NSGA-II
                 pop.ResetPopulation(multiobjective.truncatePopulation(pop.GenomeList.Count),this);
+
+
+                // TODO: Does this fix the best genome problem, or cause massive other problems selecting the
+                //       best agents? Need to focus/work more.
+
                 // Schrum: Change Fitness back to actual Fitness (rather than rank) before updating stats
                 for (int i = 0; i < pop.GenomeList.Count; i++)
                 {
@@ -409,8 +414,14 @@ namespace SharpNeatLib.Evolution
             {
 			CreateOffSpring();
 			pop.TrimAllSpeciesBackToElite();
-            // Schrum: for degugging
-                /**
+
+
+
+
+
+
+
+
                 if (generation >= 9)
                 {
                     Console.WriteLine("Population contents at generation " + generation);
@@ -422,7 +433,15 @@ namespace SharpNeatLib.Evolution
                         i++;
                     }
                 }
-                **/
+
+
+
+
+
+
+
+
+
                 // Add offspring to the population.
                 int genomeBound = offspringList.Count;
 			for(int genomeIdx=0; genomeIdx<genomeBound; genomeIdx++)
@@ -1087,8 +1106,7 @@ namespace SharpNeatLib.Evolution
                             bestGenome = fittestgenome;
                             bestGenome.objectives = (double[])fittestgenome.Behavior.objectives.Clone();
                             bestGenome.Behavior.objectives = (double[])fittestgenome.Behavior.objectives.Clone();
-                            // Schrum: for bebugging
-                            /**
+
                             if (bestGenome.Behavior.objectives != null && bestGenome.Behavior.objectives[1] == -16)
                             {
                                 Console.WriteLine("Species");
@@ -1097,7 +1115,6 @@ namespace SharpNeatLib.Evolution
                                     Console.WriteLine("\t" + (check.Behavior.objectives == null ? check.RealFitness + ",null" : string.Join(",", check.Behavior.objectives)));
                                 }
                             }
-                            **/
                         }
                     }
                 }

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -387,63 +387,23 @@ namespace SharpNeatLib.Evolution
                     regenerate=true;
                 }
             }
-
-            if (neatParameters.multiobjective) {
+            
+			if(neatParameters.multiobjective) {
 				multiobjective.addPopulation(pop);
 				multiobjective.rankGenomes();
-                // This is the command that removes excess members of the population, like in NSGA-II
-                pop.ResetPopulation(multiobjective.truncatePopulation(pop.GenomeList.Count),this);
-
-
-                // TODO: Does this fix the best genome problem, or cause massive other problems selecting the
-                //       best agents? Need to focus/work more.
-
-                // Schrum: Change Fitness back to actual Fitness (rather than rank) before updating stats
-                for (int i = 0; i < pop.GenomeList.Count; i++)
-                {
-                    // Not allowed to set Fitness to 0, so set it to MinValue if RealFitness is 0 (only true if agent is unevaluated so far)
-                    double realFitness = pop.GenomeList[i].RealFitness == 0.0 ? EvolutionAlgorithm.MIN_GENOME_FITNESS : pop.GenomeList[i].RealFitness;
-                    pop.GenomeList[i].Fitness = realFitness;
-                }
-                pop.RedetermineSpeciation(this);
-                UpdateFitnessStats();
-                DetermineSpeciesTargetSize();
-            }
-
-            if (!regenerate)
+				pop.ResetPopulation(multiobjective.truncatePopulation(pop.GenomeList.Count),this);
+				pop.RedetermineSpeciation(this);
+				UpdateFitnessStats();
+				DetermineSpeciesTargetSize();
+			}
+			
+            if(!regenerate)
             {
 			CreateOffSpring();
 			pop.TrimAllSpeciesBackToElite();
 
-
-
-
-
-
-
-
-                if (generation >= 9)
-                {
-                    Console.WriteLine("Population contents at generation " + generation);
-                    int i = 0;
-                    foreach (NeatGenome.NeatGenome g in pop.GenomeList)
-                    {
-                        if (g.Behavior != null && g.Behavior.objectives != null && g.Behavior.objectives[1] == -15) Console.Write("** ");
-                        Console.WriteLine(i + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
-                        i++;
-                    }
-                }
-
-
-
-
-
-
-
-
-
-                // Add offspring to the population.
-                int genomeBound = offspringList.Count;
+			// Add offspring to the population.
+			int genomeBound = offspringList.Count;
 			for(int genomeIdx=0; genomeIdx<genomeBound; genomeIdx++)
 				pop.AddGenomeToPopulation(this, offspringList[genomeIdx]);
 
@@ -461,7 +421,8 @@ namespace SharpNeatLib.Evolution
 			pop.IncrementGenomeAges();
 			pop.IncrementSpeciesAges();
 			generation++;
-            			
+
+			
             if(neatParameters.noveltySearch)
             {
                 Console.WriteLine("Archive size: " + this.noveltyFixed.archive.Count.ToString());
@@ -1079,48 +1040,43 @@ namespace SharpNeatLib.Evolution
 
 				// Keep track of the population's best genome and max fitness.
 				NeatGenome.NeatGenome fittestgenome = (NeatGenome.NeatGenome)(species.Members[0]);
-                // With single objective evolution, the best agent really will be at index 0
-                if (fittestgenome.RealFitness > bestFitness && !fittestgenome.Behavior.multiobjective) {
+
+                //SCHRUM: TODO: Still a problem here
+
+                if ((fittestgenome.RealFitness > bestFitness &&
+                    (bestGenome == null || // unless no best genome exists yet
+                     bestGenome.Behavior == null || bestGenome.Behavior.objectives == null || // unless other objectives are absent
+                     !fittestgenome.Behavior.multiobjective)) || // better fitness is not enough with multiobjective 
+                    // Fitness is the same, but multiple (really just 2) objectives
+                    // are being used, and this new genome performs better in that second objective.
+                   (fittestgenome.RealFitness >= bestFitness &&
+                    fittestgenome.Behavior.multiobjective &&
+                    fittestgenome.Behavior.objectives != null &&
+                    bestGenome.Behavior != null &&
+                    bestGenome.Behavior.objectives != null &&
+                    fittestgenome.Behavior.objectives[1] > bestGenome.Behavior.objectives[1]) )
+				{
+                    /**
+                    Console.WriteLine(fittestgenome);
+                    Console.WriteLine(fittestgenome.Behavior);
+                    Console.WriteLine(fittestgenome.Behavior.objectives);
+                    Console.WriteLine(fittestgenome.Behavior.objectives[0]);
+                    Console.WriteLine(fittestgenome.Behavior.objectives[1]);
+                    Console.WriteLine(bestGenome);
+                    Console.WriteLine(bestGenome.Behavior);
+                    Console.WriteLine(bestGenome.Behavior.objectives);
+                    Console.WriteLine(bestGenome.Behavior.objectives[0]);
+                    Console.WriteLine(bestGenome.Behavior.objectives[1]);
+                    **/
+                    //Console.WriteLine(fittestgenome.RealFitness + " > " + bestFitness);
+                    //Console.WriteLine("REPLACE BEST: " + (fittestgenome.Behavior == null || fittestgenome.Behavior.objectives == null ? fittestgenome.RealFitness + ",null " : fittestgenome.Behavior.objectives[0] + "," + fittestgenome.Behavior.objectives[1])
+                    //    + " is better than " + (bestGenome == null || bestGenome.Behavior == null || bestGenome.Behavior.objectives == null ? bestFitness + ",null " : bestGenome.Behavior.objectives[0] + "," + bestGenome.Behavior.objectives[1]));
+
                     bestFitness = fittestgenome.RealFitness;
 				    bestGenome = fittestgenome;
 				}
-                // With multiobjective evolution, populations get re-sorted in many different ways,
-                // not only on fitness (sorted on rank) so the whole population (species) needs to be searched
-                // to find the best agent.
-                if (neatParameters.multiobjective)
-                {
-                    foreach (NeatGenome.NeatGenome g in species.Members)
-                    {
-                        if ((fittestgenome.RealFitness > bestFitness &&
-                             (bestGenome == null || // unless no best genome exists yet 
-                              bestGenome.Behavior == null || bestGenome.Behavior.objectives == null)) // Or not evaluated 
-                             || // better fitness is not enough with multiobjective 
-                                // Fitness is the same, but multiple (really just 2) objectives
-                                // are being used, and this new genome performs better in that second objective.
-                            (fittestgenome.RealFitness >= bestFitness &&
-                             fittestgenome.Behavior.objectives != null &&
-                             bestGenome.Behavior != null &&
-                             bestGenome.Behavior.objectives != null &&
-                             fittestgenome.Behavior.objectives[1] > bestGenome.Behavior.objectives[1]))
-                        {
-                            bestFitness = fittestgenome.RealFitness;
-                            bestGenome = fittestgenome;
-                            bestGenome.objectives = (double[])fittestgenome.Behavior.objectives.Clone();
-                            bestGenome.Behavior.objectives = (double[])fittestgenome.Behavior.objectives.Clone();
-
-                            if (bestGenome.Behavior.objectives != null && bestGenome.Behavior.objectives[1] == -16)
-                            {
-                                Console.WriteLine("Species");
-                                foreach (NeatGenome.NeatGenome check in species.Members)
-                                {
-                                    Console.WriteLine("\t" + (check.Behavior.objectives == null ? check.RealFitness + ",null" : string.Join(",", check.Behavior.objectives)));
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (this.neatParameters.noveltySearch)
+				
+				if(this.neatParameters.noveltySearch)
 				{
 				  for(int x=1;x<species.Members.Count;x++)
 				    {

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -1040,15 +1040,7 @@ namespace SharpNeatLib.Evolution
 
 				// Keep track of the population's best genome and max fitness.
 				NeatGenome.NeatGenome fittestgenome = (NeatGenome.NeatGenome)(species.Members[0]);
-				if(fittestgenome.RealFitness > bestFitness ||
-                    // Fitness is the same, but multiple (really just 2) objectives
-                    // are being used, and this new genome performs better in that second objective.
-                   (fittestgenome.RealFitness == bestFitness &&
-                    fittestgenome.Behavior.multiobjective &&
-                    fittestgenome.Behavior.objectives != null &&
-                    bestGenome.Behavior != null &&
-                    bestGenome.Behavior.objectives != null &&
-                    fittestgenome.Behavior.objectives[1] > bestGenome.Behavior.objectives[1]))
+				if(fittestgenome.RealFitness > bestFitness)
 				{
                     /**
                     Console.WriteLine(fittestgenome);

--- a/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/EvolutionAlgorithm.cs
@@ -393,16 +393,15 @@ namespace SharpNeatLib.Evolution
 				multiobjective.rankGenomes();
 
                 // Schrum: for degugging
-                /*
+                /**
                 Console.WriteLine("Population contents at generation " + generation);
                 int k = 0;
                 foreach (NeatGenome.NeatGenome g in pop.GenomeList)
                 {
-                    Console.WriteLine(k + ": " + g.GenomeId + ":" + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
+                    Console.WriteLine(k + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
                     k++;
                 }
-                */
-        
+                **/
                 // This is the command that removes excess members of the population, like in NSGA-II
                 pop.ResetPopulation(multiobjective.truncatePopulation(pop.GenomeList.Count), this);
                 // Schrum: Change Fitness back to actual Fitness (rather than rank) before updating stats

--- a/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
@@ -21,6 +21,29 @@ namespace SharpNeatLib.Evolution
             else if (fitnessDelta > 0.0D)
                 return 1;
 
+            // Schrum: for multiobjective comparison with one "real" objective and a secondary objective.
+            //         First objective is still most important, but second objective breaks ties.
+            //         Also, only apply when the Fitness is not the "rank" for multiobjective sorting
+            //         (Fitness is not always the RealFitness when this comparer is used)
+            if(x.objectives != null && y.objectives != null && // multiple objectives exist
+               x.objectives[0] == x.Fitness && y.objectives[0] == y.Fitness) // Currently sorting by real fitness and not rank
+            {
+                double secondFitnessDelta = y.objectives[1] - x.objectives[1];
+                if (secondFitnessDelta < 0.0D)
+                    return -1;
+                else if (secondFitnessDelta > 0.0D)
+                    return 1;
+            }
+
+            // FIX: This section below seems to cause problems. It seems to prevent new genomes from ever having a chance.
+
+            // Schrum: Trust genomes that have experienced an evaluation over others.
+            //         Might contradict the original intention of the age comparison below.
+            if (x.objectives == null && y.objectives != null)
+                return 1; // y is "better" since it has been evaluated, but x has not
+            else if (x.objectives != null && y.objectives == null)
+                return -1; // x is "better" since it has been evaluated, but y has not
+
             long ageDelta = x.GenomeAge - y.GenomeAge;
 
             // Convert result to an int.

--- a/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
@@ -26,14 +26,7 @@ namespace SharpNeatLib.Evolution
             // objective is the same, since we assume the first objective is the only
             // "real" objective. Second objective could be negative CPPN link count or
             // negative substrate link count.
-
-            // ALSO: The Fitness has different values during multiobjective population sorting
-            // (for example, "rank") so I also make sure that the Fitness equals the value of the
-            // first objective before using the second objective as a tie-breaker.
-            if (x.Behavior.multiobjective && // multiobjective evolution (only makes sense for 2 objectives where the second is a meta-objective)
-                x.Fitness != 0 && // 0 fitness means the genome was just initialized, and hasn't been evaluated yet
-                x.Behavior.objectives != null && y.Behavior.objectives != null && // Make sure objectives have been provided
-                x.Fitness == x.Behavior.objectives[0]) // Make sure Fitness hasn't been swapped with rank during Pareto layer sorting
+            if (x.Behavior.multiobjective && x.Fitness != 0 && x.Behavior.objectives != null && y.Behavior.objectives != null)
             {
                 // Schrum:
                 // Apparently, genomes with fitness 0 get "sorted" after creation, but before evaluation.

--- a/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
@@ -21,23 +21,6 @@ namespace SharpNeatLib.Evolution
             else if (fitnessDelta > 0.0D)
                 return 1;
 
-            // Schrum: a hack. Currently, we know there will only be two objectives.
-            // So, just check the second. Make sure that second is tie-breaker when first
-            // objective is the same, since we assume the first objective is the only
-            // "real" objective. Second objective could be negative CPPN link count or
-            // negative substrate link count.
-            if (x.Behavior.multiobjective && x.Behavior.objectives != null && y.Behavior.objectives != null)
-            {
-                // Second objective in index 1
-                double secondObjectiveDelta = y.Behavior.objectives[1] - x.Behavior.objectives[1];
-                if (secondObjectiveDelta < 0.0D)
-                    return -1;
-                else if (secondObjectiveDelta > 0.0D)
-                    return 1;
-            }
-
-            // Schrum: Not sure if comparing based on age is really a good idea.
-            //         Wonder why this is here.
             long ageDelta = x.GenomeAge - y.GenomeAge;
 
             // Convert result to an int.

--- a/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
@@ -49,12 +49,6 @@ namespace SharpNeatLib.Evolution
                     return 1;
             }
 
-            // Schrum: Trust genomes that have experienced an evaluation over others
-            if (x.Behavior.objectives == null && y.Behavior.objectives != null)
-                return 1; // y is "better" since it has been evaluated, but x has not
-            else if (x.Behavior.objectives != null && y.Behavior.objectives == null)
-                return -1; // x is "better" since it has been evaluated, but y has not
-
             // Schrum: Not sure if comparing based on age is really a good idea.
             //         Wonder why this is here.
             long ageDelta = x.GenomeAge - y.GenomeAge;

--- a/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
@@ -26,14 +26,8 @@ namespace SharpNeatLib.Evolution
             // objective is the same, since we assume the first objective is the only
             // "real" objective. Second objective could be negative CPPN link count or
             // negative substrate link count.
-            if (x.Behavior.multiobjective && x.Fitness != 0 && x.Behavior.objectives != null && y.Behavior.objectives != null)
+            if (x.Behavior.multiobjective && x.Behavior.objectives != null && y.Behavior.objectives != null)
             {
-                // Schrum:
-                // Apparently, genomes with fitness 0 get "sorted" after creation, but before evaluation.
-                // In this case, 0 is the worst possible fitness, but not Behavior or objectives will be defined.
-                // However, at this point in the code, if one fitness is 0, then both must be, meaning we can skip
-                // this code and rely on age, as below.
-
                 // Second objective in index 1
                 double secondObjectiveDelta = y.Behavior.objectives[1] - x.Behavior.objectives[1];
                 if (secondObjectiveDelta < 0.0D)

--- a/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/GenomeComparer.cs
@@ -21,29 +21,6 @@ namespace SharpNeatLib.Evolution
             else if (fitnessDelta > 0.0D)
                 return 1;
 
-            // Schrum: for multiobjective comparison with one "real" objective and a secondary objective.
-            //         First objective is still most important, but second objective breaks ties.
-            //         Also, only apply when the Fitness is not the "rank" for multiobjective sorting
-            //         (Fitness is not always the RealFitness when this comparer is used)
-            if(x.objectives != null && y.objectives != null && // multiple objectives exist
-               x.objectives[0] == x.Fitness && y.objectives[0] == y.Fitness) // Currently sorting by real fitness and not rank
-            {
-                double secondFitnessDelta = y.objectives[1] - x.objectives[1];
-                if (secondFitnessDelta < 0.0D)
-                    return -1;
-                else if (secondFitnessDelta > 0.0D)
-                    return 1;
-            }
-
-            // FIX: This section below seems to cause problems. It seems to prevent new genomes from ever having a chance.
-
-            // Schrum: Trust genomes that have experienced an evaluation over others.
-            //         Might contradict the original intention of the age comparison below.
-            if (x.objectives == null && y.objectives != null)
-                return 1; // y is "better" since it has been evaluated, but x has not
-            else if (x.objectives != null && y.objectives == null)
-                return -1; // x is "better" since it has been evaluated, but y has not
-
             long ageDelta = x.GenomeAge - y.GenomeAge;
 
             // Convert result to an int.

--- a/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
@@ -279,12 +279,12 @@ namespace SharpNeatLib.Multiobjective
 
             // Schrum: print members to be removed
             /*
-            for(int k = size; k < to_remove; k++)
+            for(int k = size; k < population.Count; k++)
             {
                 Console.WriteLine("REMOVE:" + population[k].RealFitness + "," + population[k].Behavior.objectives[1]);
             }
             */
-            
+
 			if(to_remove>0)
 	  			population.RemoveRange(size,to_remove);
 

--- a/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
@@ -173,168 +173,106 @@ namespace SharpNeatLib.Multiobjective
 		
 		//add an existing population from hypersharpNEAT to the multiobjective population maintained in
 		//this class, step taken before evaluating multiobjective population through the rank function
-        public void addPopulation(Population p)
-        {
-            for (int i = 0; i < p.GenomeList.Count; i++)
-            {
-                // Schrum: debugging
-                /*
-                if (p.GenomeList[i].GenomeId == 3689)
-                {
-                    Console.WriteLine("Considering adding 3689");
-                }
-                 */
-
-                bool blacklist = false;
-                for (int j = 0; j < population.Count; j++)
-                {
-                    double dist = distance(p.GenomeList[i].Behavior.objectives, population[j].objectives);
-                    /* 
-                    if (p.GenomeList[i].GenomeId == 3689)
-                    {
-                        Console.WriteLine("\tcompare" + p.GenomeList[i].GenomeId + ":" + p.GenomeList[i].RealFitness + "," + p.GenomeList[i].Behavior.objectives[1] + ":::" + string.Join(",", p.GenomeList[i].Behavior.objectives) + " compared to " + string.Join(",", population[j].objectives) + " result dist " + dist);
-                    }
-                    */
-                    if (dist < 0.01)
-                    {
-                        //if (p.GenomeList[i].GenomeId == 3689)
-                        //    Console.WriteLine("Blacklisting 3689!");
-    
-                        blacklist = true;  //reject a genome if it is very similar to existing genomes in pop
-                    }
-                }
-                if (!blacklist)
-                {
-                    //add genome if it is unique
-                    //we might not need to make copies
-                    NeatGenome.NeatGenome copy = new NeatGenome.NeatGenome((NeatGenome.NeatGenome)p.GenomeList[i], 0);
-                    copy.objectives = (double[])p.GenomeList[i].Behavior.objectives.Clone();
-                    population.Add(copy);
-
-                    /*
-                    if (p.GenomeList[i].GenomeId == 3689)
-                    {
-                        Console.WriteLine("Adding 3689 at " + population.Count + ":" + copy.RealFitness + ":" + copy.Fitness + ":" + string.Join(",", copy.objectives));
-                    }
-                    **/
-                }
-
-            }
-
-            // Schrum: debugging: after adding ... is it not here?
-            /*
-            int k = 0;
-            foreach (NeatGenome.NeatGenome g in population)
-            {
-                Console.WriteLine(k + ": " + g.GenomeId + ":" + g.RealFitness + "," + g.Fitness + "," + g.objectives[0] + "," + g.objectives[1]);
-                k++;
-            }
-            */
-        }
+		public void addPopulation(Population p) {
+			for(int i=0;i<p.GenomeList.Count;i++)
+		    {
+		        bool blacklist=false;
+				for(int j=0;j<population.Count;j++)
+				{
+				 if(distance(p.GenomeList[i].Behavior.objectives,population[j].objectives) < 0.01)
+						blacklist=true;  //reject a genome if it is very similar to existing genomes in pop
+				}
+				if(!blacklist) { //add genome if it is unique
+				//we might not need to make copies
+				NeatGenome.NeatGenome copy=new NeatGenome.NeatGenome((NeatGenome.NeatGenome)p.GenomeList[i],0);
+				copy.objectives = (double[])p.GenomeList[i].Behavior.objectives.Clone();
+				population.Add(copy);    
+				}	
+				
+			}
+		}
 
 		public void rankGenomes() {
-            // Schrum: debugging
-
-            Console.WriteLine("pop before ranking");
-            int k = 0;
-            foreach (NeatGenome.NeatGenome g in population)
-            {
-                Console.WriteLine(k + ": " + g.GenomeId + ":" + g.RealFitness + "," + g.Fitness + "," + g.objectives[0] + "," + g.objectives[1]);
-                k++;
-            }
-
-            int size = population.Count;
-
-            // Schrum: Originally, calculateGenomicNovelty was outside of this "if" but it was clearly causing problems
-            // with my multiobjective experiments. I feel like this might break some results from Joel's older papers though.
-            if (doNovelty)
-            {
-                calculateGenomicNovelty();
-                measure_novelty();
-            }
-
-            //reset rank information
-            for (int i = 0; i < size; i++)
-            {
-                if (ranks.Count < i + 1)
-                    ranks.Add(new RankInformation());
-                else
-                    ranks[i].reset();
-            }
-            //calculate domination by testing each genome against every other genome
-            for (int i = 0; i < size; i++)
-            {
-                for (int j = 0; j < size; j++)
-                {
-                    update_domination((NeatGenome.NeatGenome)population[i], (NeatGenome.NeatGenome)population[j], ranks[i], ranks[j]);
-                }
-            }
-
-            //successively peel off non-dominated fronts (e.g. those genomes no longer dominated by any in
-            //the remaining population)
-            List<int> front = new List<int>();
-            int ranked_count = 0;
-            int current_rank = 1;
-            while (ranked_count < size)
-            {
-                //search for non-dominated front
-                for (int i = 0; i < size; i++)
-                {
-                    //continue if already ranked
-                    if (ranks[i].ranked) continue;
-                    //if not dominated, add to front
-                    if (ranks[i].domination_count == 0)
-                    {
-                        front.Add(i);
-                        ranks[i].ranked = true;
-                        ranks[i].rank = current_rank;
-                    }
-                }
-
-                int front_size = front.Count;
-                //Console.WriteLine("Front " + current_rank + " size: " + front_size);
-
-                //now take all the non-dominated individuals, see who they dominated, and decrease
-                //those genomes' domination counts, because we are removing this front from consideration
-                //to find the next front of individuals non-dominated by the remaining individuals in
-                //the population
-                for (int i = 0; i < front_size; i++)
-                {
-                    RankInformation r = ranks[front[i]];
-                    foreach (RankInformation dominated in r.dominates)
-                    {
-                        dominated.domination_count--;
-                    }
-                }
-
-                ranked_count += front_size;
-                front.Clear();
-                current_rank++;
-            }
-
-            //we save the last objective for potential use as genomic novelty objective
-            int last_obj = population[0].objectives.Length - 1;
-
-            //fitness = popsize-rank (better way might be maxranks+1-rank), but doesn't matter
-            //because speciation is not used and tournament selection is employed
-            for (int i = 0; i < size; i++)
-            {
-                population[i].Fitness = (size + 1) - ranks[i].rank;//+population[i].objectives[last_obj]/100000.0;
-            }
-
-            population.Sort();
-            generation++;
+		  int size = population.Count;
+			
+			calculateGenomicNovelty();
+		 if(doNovelty) {
+			measure_novelty();
+			}
+			
+		  //reset rank information
+		  for(int i=0;i<size;i++) {
+		    if(ranks.Count<i+1)
+				ranks.Add(new RankInformation());
+			else
+				ranks[i].reset();
+		  }
+			//calculate domination by testing each genome against every other genome
+			for(int i=0;i<size;i++) {
+				for(int j=0;j<size;j++) {
+					update_domination((NeatGenome.NeatGenome)population[i],(NeatGenome.NeatGenome)population[j],ranks[i],ranks[j]);
+				}
+			}
+			
+			//successively peel off non-dominated fronts (e.g. those genomes no longer dominated by any in
+			//the remaining population)
+			List<int> front = new List<int>();
+			int ranked_count=0;
+			int current_rank=1;
+			while(ranked_count < size) {
+				//search for non-dominated front
+				for(int i=0;i<size;i++)
+				{
+					//continue if already ranked
+					if(ranks[i].ranked) continue;
+					//if not dominated, add to front
+					if(ranks[i].domination_count==0) {
+						front.Add(i);
+						ranks[i].ranked=true;
+						ranks[i].rank=current_rank;
+					}
+				}
+				
+				int front_size = front.Count;
+				//Console.WriteLine("Front " + current_rank + " size: " + front_size);
+				
+				//now take all the non-dominated individuals, see who they dominated, and decrease
+				//those genomes' domination counts, because we are removing this front from consideration
+				//to find the next front of individuals non-dominated by the remaining individuals in
+				//the population
+				for(int i=0;i<front_size;i++) {
+					RankInformation r = ranks[front[i]];
+					foreach (RankInformation dominated in r.dominates) {
+						dominated.domination_count--;
+					}
+				}
+				
+				ranked_count+=front_size;
+				front.Clear();
+				current_rank++;
+			}
+			
+			//we save the last objective for potential use as genomic novelty objective
+			int last_obj=population[0].objectives.Length-1;
+			
+			//fitness = popsize-rank (better way might be maxranks+1-rank), but doesn't matter
+			//because speciation is not used and tournament selection is employed
+			for(int i=0;i<size;i++) {
+				population[i].Fitness = (size+1)-ranks[i].rank;//+population[i].objectives[last_obj]/100000.0;
+			}
+			
+			population.Sort();
+			generation++;
             // Schrum: not really using this. Output overlaps when multiple runs happen, which is annoying
-            //if(generation%250==0)
-            //this.printDistribution();
-        }
+			//if(generation%250==0)
+			//this.printDistribution();
+		}
 		
 		
 		//when we merge populations together, often the population will overflow, and we need to cut
 		//it down. to do so, we just remove the last x individuals, which will be in the less significant
 		//pareto fronts
 		public GenomeList truncatePopulation(int size) {
-            
 			int to_remove=population.Count - size;
 			Console.WriteLine("population size before: " + population.Count);
 			Console.WriteLine("removing " + to_remove);
@@ -352,15 +290,6 @@ namespace SharpNeatLib.Multiobjective
 
             Console.WriteLine("population size after: " + population.Count);
 
-            // Schrum: for debugging
-            /*
-            int k = 0;
-            foreach (NeatGenome.NeatGenome g in population)
-            {
-                Console.WriteLine(k + ": " + g.GenomeId + ":" + g.RealFitness + "," + g.Fitness + "," + g.objectives[0] + "," + g.objectives[1]);
-                k++;
-            }
-            */
 			return population;
 		}
 		

--- a/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
@@ -95,15 +95,10 @@ namespace SharpNeatLib.Multiobjective
 				if(objx[i]>objy[i]) better=true;
 			}
 			//genomic novelty check, disabled for now
-            /**
-             * Schrum: I removed this. This seems to have been some special case handling for
-             * novelty search and/or behavioral diversity, but it doesn't make sense when doing
-             * plain multiobjective optimization. This also explains why the change in the loop
-             * above from sz-1 to sz had to happen.
 			double thresh=0.1;
 			if((objx[sz-1]+thresh)<(objy[sz-1])) return false;
 			if((objx[sz-1]>(objy[sz-1]+thresh))) better=true;
-			**/
+			
 			return better;
 		}
 		
@@ -276,19 +271,9 @@ namespace SharpNeatLib.Multiobjective
 			int to_remove=population.Count - size;
 			Console.WriteLine("population size before: " + population.Count);
 			Console.WriteLine("removing " + to_remove);
-
-            // Schrum: print members to be removed
-            /*
-            for(int k = size; k < population.Count; k++)
-            {
-                Console.WriteLine("REMOVE:" + population[k].RealFitness + "," + population[k].Behavior.objectives[1]);
-            }
-            */
-
 			if(to_remove>0)
 	  			population.RemoveRange(size,to_remove);
-
-            Console.WriteLine("population size after: " + population.Count);
+						Console.WriteLine("population size after: " + population.Count);
 
 			return population;
 		}

--- a/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Multiobjective.cs
@@ -234,7 +234,7 @@ namespace SharpNeatLib.Multiobjective
 
 		public void rankGenomes() {
             // Schrum: debugging
-            /*
+
             Console.WriteLine("pop before ranking");
             int k = 0;
             foreach (NeatGenome.NeatGenome g in population)
@@ -242,7 +242,7 @@ namespace SharpNeatLib.Multiobjective
                 Console.WriteLine(k + ": " + g.GenomeId + ":" + g.RealFitness + "," + g.Fitness + "," + g.objectives[0] + "," + g.objectives[1]);
                 k++;
             }
-            */
+
             int size = population.Count;
 
             // Schrum: Originally, calculateGenomicNovelty was outside of this "if" but it was clearly causing problems

--- a/AgentSimulator/SharpNeatLib/Evolution/Population.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Population.cs
@@ -411,7 +411,6 @@ namespace SharpNeatLib.Evolution
                 speciesToRemove.Add(species.SpeciesId);
             }
 
-            // Schrum: Figure out what is being removed here and why
             int speciesBound = speciesToRemove.Count;
             for (int speciesIdx = 0; speciesIdx < speciesBound; speciesIdx++)
                 speciesTable.Remove(speciesToRemove[speciesIdx]);

--- a/AgentSimulator/SharpNeatLib/Evolution/Population.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Population.cs
@@ -402,46 +402,22 @@ namespace SharpNeatLib.Evolution
 		}
 
 
-        public void ResetPopulation(GenomeList l, EvolutionAlgorithm ea)
+		public void ResetPopulation(GenomeList l, EvolutionAlgorithm ea)
         {
-            speciesToRemove.Clear();
+			speciesToRemove.Clear();
 
-            foreach (Species species in speciesTable.Values)
+            foreach(Species species in speciesTable.Values)
             {
-                speciesToRemove.Add(species.SpeciesId);
+            	speciesToRemove.Add(species.SpeciesId);		
             }
 
-            int speciesBound = speciesToRemove.Count;
-            for (int speciesIdx = 0; speciesIdx < speciesBound; speciesIdx++)
-                speciesTable.Remove(speciesToRemove[speciesIdx]);
-
-            for (int i = 0; i < l.Count; i++)
-                this.AddGenomeToPopulation(ea, l[i]);
-
-            // Schrum: debugging
-            /**
-            Console.WriteLine("Population contents");
-            int k = 0;
-            foreach (NeatGenome.NeatGenome g in GenomeList)
-            {
-                Console.WriteLine(k + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
-                k++;
-            }
+			int speciesBound=speciesToRemove.Count;
+			for(int speciesIdx=0; speciesIdx<speciesBound; speciesIdx++)
+				speciesTable.Remove(speciesToRemove[speciesIdx]);
             
-            Console.WriteLine("Species contents");
-            k = 0;
-            int specNum = 0;
-            foreach (Species s in speciesTable.Values)
-            { 
-                foreach (NeatGenome.NeatGenome g in s.Members)
-                {
-                    Console.WriteLine(specNum + ":" + k + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
-                    k++;
-                }
-                specNum++;
-            }
-            **/
-
+            for(int i=0;i<l.Count;i++)
+                this.AddGenomeToPopulation(ea,l[i]);
+                
             this.RebuildGenomeList();
         }
         

--- a/AgentSimulator/SharpNeatLib/Evolution/Population.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Population.cs
@@ -365,16 +365,8 @@ namespace SharpNeatLib.Evolution
 			// away as we would be modifying the structrue we are looping through.
 			foreach(Species species in speciesTable.Values)
 			{
-                if (species.TargetSize == 0)
-                {
-                    speciesToRemove.Add(species.SpeciesId);
-
-                    Console.WriteLine("REMOVE SPECIES: " + species.SpeciesId);
-                    foreach(NeatGenome.NeatGenome genome in species.Members)
-                    {
-                        Console.WriteLine("\t"+ genome.RealFitness + "," + (genome.Behavior == null || genome.Behavior.objectives == null ? "null" : ""+ genome.Behavior.objectives[1]));
-                    }
-                }
+				if(species.TargetSize==0)
+					speciesToRemove.Add(species.SpeciesId);
 			}
 
 			// Remove the poor species.

--- a/AgentSimulator/SharpNeatLib/Evolution/Population.cs
+++ b/AgentSimulator/SharpNeatLib/Evolution/Population.cs
@@ -404,34 +404,21 @@ namespace SharpNeatLib.Evolution
 
         public void ResetPopulation(GenomeList l, EvolutionAlgorithm ea)
         {
-            // Schrum: debugging
-            /** 
-            Console.WriteLine("GenomeList l");
-            int k = 0;
-            foreach (NeatGenome.NeatGenome g in l)
-            {
-                Console.WriteLine(k + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
-                k++;
-            }
-            */
-
             speciesToRemove.Clear();
 
-            // Remove all species (genomes still in population)
             foreach (Species species in speciesTable.Values)
             {
                 speciesToRemove.Add(species.SpeciesId);
             }
 
+            // Schrum: Figure out what is being removed here and why
             int speciesBound = speciesToRemove.Count;
             for (int speciesIdx = 0; speciesIdx < speciesBound; speciesIdx++)
                 speciesTable.Remove(speciesToRemove[speciesIdx]);
 
-            // Add new genomes to population and to species table
-            for (int i = 0; i < l.Count; i++) {
-                //Console.WriteLine("AddGenomeToPopulation:" + l[i].GenomeId + ":" + l[i].RealFitness + "," + l[i].Fitness + "," + l[i].objectives[0] + "," + l[i].objectives[1]);
+            for (int i = 0; i < l.Count; i++)
                 this.AddGenomeToPopulation(ea, l[i]);
-            }
+
             // Schrum: debugging
             /**
             Console.WriteLine("Population contents");
@@ -443,21 +430,19 @@ namespace SharpNeatLib.Evolution
             }
             
             Console.WriteLine("Species contents");
-            int k = 0;
+            k = 0;
             int specNum = 0;
             foreach (Species s in speciesTable.Values)
             { 
                 foreach (NeatGenome.NeatGenome g in s.Members)
                 {
-                    Console.WriteLine(specNum + ":" + k + ": " + g.GenomeId + ":" + g.RealFitness + "," + g.Fitness + "," + g.objectives[0] + "," + g.objectives[1]);
+                    Console.WriteLine(specNum + ":" + k + ": " + g.RealFitness + "," + (g.Behavior == null || g.Behavior.objectives == null ? "null" : "" + g.Behavior.objectives[1]));
                     k++;
                 }
                 specNum++;
             }
             **/
 
-            // Destroys the genome list and rebuilds is from the species table.
-            // Basically, only genomes from input parameter l will still be present.
             this.RebuildGenomeList();
         }
         

--- a/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
+++ b/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
@@ -39,4 +39,3 @@ E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\D
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csproj.GenerateResource.Cache
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.dll
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.pdb
-E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csprojResolveAssemblyReference.cache

--- a/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
+++ b/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
@@ -40,3 +40,4 @@ E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\D
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csproj.GenerateResource.Cache
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.dll
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.pdb
+C:\Users\Jacob\Documents\Visual Studio 2010\Projects\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csprojResolveAssemblyReference.cache

--- a/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
+++ b/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
@@ -41,3 +41,11 @@ E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\D
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.dll
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.pdb
 C:\Users\Jacob\Documents\Visual Studio 2010\Projects\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csprojResolveAssemblyReference.cache
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\bin\Debug\SharpNeatLib.dll
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\bin\Debug\SharpNeatLib.pdb
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.Experiments.AbstractExperimentView.resources
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.NetworkVisualization.NetworkControl.resources
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.NetworkVisualization.Viewport.resources
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csproj.GenerateResource.Cache
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.dll
+D:\GitHub\troubleshoot\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.pdb

--- a/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
+++ b/AgentSimulator/SharpNeatLib/obj/Debug/SharpNeatLib.csproj.FileListAbsolute.txt
@@ -30,6 +30,7 @@ C:\Users\Jacob\Documents\Visual Studio 2010\Projects\agent_multimodal\AgentSimul
 C:\Users\Jacob\Documents\Visual Studio 2010\Projects\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csproj.GenerateResource.Cache
 C:\Users\Jacob\Documents\Visual Studio 2010\Projects\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.dll
 C:\Users\Jacob\Documents\Visual Studio 2010\Projects\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.pdb
+D:\GitHub\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csprojResolveAssemblyReference.cache
 C:\Users\He_Deceives\Documents\Visual Studio 2010\Projects\agent_multimodal\AgentSimulator\SharpNeatLib\obj\Debug\SharpNeatLib.csprojResolveAssemblyReference.cache
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\bin\Debug\SharpNeatLib.dll
 E:\Users\he_de\CSharpResearch\agent_multimodal\AgentSimulator\SharpNeatLib\bin\Debug\SharpNeatLib.pdb


### PR DESCRIPTION
There were definitely some problems with multiobjective selection. I tried to fix them in your original repository, but it became such a mess that I forked this one, reverted my changes, and then proceeded with a cleaner solution. The major issues were that:
1) The last objective was being overwritten by a diversity measure, which seemed to actually encourage genomes with lots of extra modules and links (opposite of what I wanted). I removed the special handling of the last objective, which probably breaks some of your older experiments with this code, but makes more sense in general.
2) The best genome tracking was improved for the multiobjective case. I suppose that with multiple objectives, it makes more sense to rely on the population output files. However, my multiobjective cases generally involve one "real" objective and a "secondary" objective (number of links in CPPN of Substrate), so I updated the tracking of best to favor the best real fitness, but also use the secondary fitness to break ties.

These changes prevent the secondary objective score from going up when the primary/real objective is not increasing, which is good. However, two test runs I did basically stagnated forever with poor performance. Though not a desirable result, I'm not sure that it is in any way incorrect. I would like to merge these changes back into the main repository (which is honestly in a bit of a messy state right now) and resume tackling the issue from there.